### PR TITLE
Optional delay before dbinit

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,10 +1,10 @@
 import enum
 import os
-import sys
+import time
 
 from sqlalchemy import (Column, create_engine, Enum, ForeignKey,
                         Integer, JSON, LargeBinary, String)
-from sqlalchemy.orm import relationship, scoped_session, sessionmaker
+from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 
 
@@ -55,7 +55,17 @@ def init_db():
 
 
 if __name__ == '__main__':
-    if len(sys.argv) == 2 and sys.argv[1] == 'init':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", help="Command to run")
+    parser.add_argument("-s", "--sleep", help="Delay in seconds before initializing database",
+                        type=float, default=1)
+    args = parser.parse_args()
+    time.sleep(args.sleep)
+
+    if args.command == 'init':
+        print("Initialising database...")
         init_db()
     else:
-        'To create database: python database.py init'
+        print('Command not recognized init')

--- a/k8s-deployment/encoding-service/templates/encoding-dbinit-job.yaml
+++ b/k8s-deployment/encoding-service/templates/encoding-dbinit-job.yaml
@@ -21,6 +21,7 @@ spec:
         command:
         - python3
         - database.py
+        - --sleep 60
         - init
         env:
         - name: CLKHASH_SERVICE_DB_URI


### PR DESCRIPTION
While testing the k8s deployment of the encoding service I noticed that sometimes the database isn't provisioned because the init_db job runs before the database has its volumes in order.

This (hack) just adds an optional configurable delay (default to 1s normally and 60 s for k8s)