### PR TITLE
Update PyYAML and fix PEP 479

### DIFF
--- a/clkhash_service.py
+++ b/clkhash_service.py
@@ -73,7 +73,10 @@ def _abort_if_project_not_found(function):
 
 def _intersperse(iterable, item):
     iterator = iter(iterable)  # Remember where we left off
-    yield next(iterator)  # Exit StopIteration if empty
+    try:
+        yield next(iterator)
+    except StopIteration:
+        return
     for i in iterator:
         yield item
         yield i

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ mypy-extensions==0.3.0
 psycopg2==2.7.4
 pycparser==2.18
 pytz==2018.4
-PyYAML==3.12
+PyYAML==3.13
 requests==2.20.0
 six==1.11.0
 SQLAlchemy==1.2.8


### PR DESCRIPTION
PyYAML has a security vulnerability. See #32. This fixes #32.

Also fixes a PEP 479 issue that caused `RuntimeError`s in newer versions of Python.