### PR TITLE
Update Jinja2 for CVE-2019-10906

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ future==0.16.0
 idna==2.7
 inflection==0.3.1
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2>=2.10.1
 jsonschema==2.6.0
 kombu==4.2.1
 MarkupSafe==1.0


### PR DESCRIPTION
GitHub thinks Jinja2 needs an update to avoid this:
https://nvd.nist.gov/vuln/detail/CVE-2019-10906